### PR TITLE
Can change the date and will update the database

### DIFF
--- a/scripts/dashboard/fitbit_app.py
+++ b/scripts/dashboard/fitbit_app.py
@@ -35,10 +35,6 @@ selected_user = st.sidebar.selectbox(
     options=("All",) + fitbit_db.user_ids
 )
 
-# Un-comment this to see the corresponding user's id on the dashboard
-# if selected_user:
-#     st.write(selected_user)
-
 left, right = st.sidebar.columns(2)
 with left: 
     start_date = st.date_input(

--- a/scripts/database.py
+++ b/scripts/database.py
@@ -43,10 +43,10 @@ class FitbitDatabase:
         df = self.dataframe_from_query(query)
         df["Date"] = pd.to_datetime(df["Date"])
 
-        min_date = df["Date"].min().to_pydatetime()
-        max_date = df["Date"].max().to_pydatetime()
+        first_date = df["Date"].min().to_pydatetime()
+        last_date = df["Date"].max().to_pydatetime()
 
-        return (min_date, max_date)
+        return (first_date, last_date)
 
     def get_sleep_moments(self, user_id: float) -> pd.DataFrame:
         query = """


### PR DESCRIPTION
There's still a UI bug where if you change the start/end date's input on one of them, and then try to change it on the other, it will reset the date to what it currently is.

For example, if i set start date to March 20 and then try to set the end date to April 1, it will reset the end date to what it currently was.

It does that to reset the UI to account for the user's inputted start date by blocking off anything before March 20.